### PR TITLE
Improve the `manage.py create_tenant` command

### DIFF
--- a/wagtail_tenants/management/commands/create_tenant.py
+++ b/wagtail_tenants/management/commands/create_tenant.py
@@ -79,7 +79,10 @@ class Command(BaseCommand):
                                 input_msg,
                                 default,
                             )
-
+                        elif field.get_internal_type() == "DateField":
+                            input_msg = "%s ('YYYY-MM-DD')" % (input_msg)
+                        elif field.get_internal_type() == "BooleanField":
+                            input_msg = "%s ('True' or 'False')" % (input_msg)
                         input_value = input(force_str("%s: " % input_msg)) or default
                         tenant_data[field.attname] = input_value
                 tenant = self.store_tenant(**tenant_data)
@@ -103,7 +106,6 @@ class Command(BaseCommand):
                                 input_msg,
                                 default,
                             )
-
                         input_value = input(force_str("%s: " % input_msg)) or default
                         domain_data[field.attname] = input_value
                 domain = self.store_tenant_domain(**domain_data)
@@ -131,7 +133,8 @@ class Command(BaseCommand):
         except exceptions.ValidationError as e:
             self.stderr.write("Error: %s" % "; ".join(e.messages))
             return None
-        except IntegrityError:
+        except IntegrityError as e:
+            self.stderr.write("%s" % e)
             return None
 
     def store_tenant_domain(self, **fields):
@@ -142,5 +145,6 @@ class Command(BaseCommand):
         except exceptions.ValidationError as e:
             self.stderr.write("Error: %s" % "; ".join(e.messages))
             return None
-        except IntegrityError:
+        except IntegrityError as e:
+            self.stderr.write("%s" % e)
             return None

--- a/wagtail_tenants/management/commands/create_tenant.py
+++ b/wagtail_tenants/management/commands/create_tenant.py
@@ -1,7 +1,146 @@
-from django_tenants.management.commands.create_tenant import (
-    Command as CreateTenantCommand,
-)
+from django.core import exceptions
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+from django.db.utils import IntegrityError
+from django.utils.encoding import force_str
+from django_tenants.utils import get_tenant_model, get_tenant_domain_model
 
 
-class Command(CreateTenantCommand):
-    ...
+class Command(BaseCommand):
+    help = "Create a tenant"
+
+    # Only use editable fields
+    # noinspection PyProtectedMember
+    tenant_fields = [
+        field
+        for field in get_tenant_model()._meta.fields
+        if field.editable and not field.primary_key
+    ]
+    # noinspection PyProtectedMember
+    domain_fields = [
+        field
+        for field in get_tenant_domain_model()._meta.fields
+        if field.editable and not field.primary_key
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def add_arguments(self, parser):
+        for field in self.tenant_fields:
+            parser.add_argument(
+                "--%s" % field.attname,
+                help="Specifies the %s for tenant." % field.attname,
+            )
+
+        for field in self.domain_fields:
+            parser.add_argument(
+                "--domain-%s" % field.attname,
+                help="Specifies the %s for the tenant's domain." % field.attname,
+            )
+
+        parser.add_argument(
+            "--noinput",
+            "--no-input",
+            action="store_false",
+            dest="interactive",
+            help=(
+                "Tells Django to NOT prompt the user for input of any kind. "
+                "You must use --schema_names with --noinput, along with an option for "
+                "any other required field."
+            ),
+        )
+
+        parser.add_argument(
+            "-s", action="store_true", help="Create a superuser afterwards."
+        )
+
+    def handle(self, *args, **options):
+        tenant_data = {}
+        for field in self.tenant_fields:
+            input_value = options.get(field.attname, None)
+            if input_value is not None:
+                tenant_data[field.attname] = field.clean(input_value, None)
+
+        domain_data = {}
+        for field in self.domain_fields:
+            input_value = options.get("domain_%s" % field.attname, None)
+            if input_value is not None:
+                domain_data[field.attname] = field.clean(input_value, None)
+
+        if options["interactive"]:
+            while True:
+                for field in self.tenant_fields:
+                    if tenant_data.get(field.attname, "") == "":
+                        input_msg = field.verbose_name
+                        default = field.get_default()
+                        if default:
+                            input_msg = "%s (leave blank to use '%s')" % (
+                                input_msg,
+                                default,
+                            )
+
+                        input_value = input(force_str("%s: " % input_msg)) or default
+                        tenant_data[field.attname] = input_value
+                tenant = self.store_tenant(**tenant_data)
+                if tenant is not None:
+                    break
+                tenant_data = {}
+        else:
+            tenant = self.store_tenant(**tenant_data)
+            if tenant is None:
+                raise CommandError("Missing required fields")
+
+        if options["interactive"]:
+            while True:
+                domain_data["tenant_id"] = tenant.pk
+                for field in self.domain_fields:
+                    if domain_data.get(field.attname, "") == "":
+                        input_msg = field.verbose_name
+                        default = field.get_default()
+                        if default:
+                            input_msg = "%s (leave blank to use '%s')" % (
+                                input_msg,
+                                default,
+                            )
+
+                        input_value = input(force_str("%s: " % input_msg)) or default
+                        domain_data[field.attname] = input_value
+                domain = self.store_tenant_domain(**domain_data)
+                if domain is not None:
+                    break
+                domain_data = {}
+        else:
+            domain_data["tenant_id"] = tenant.pk
+            domain = self.store_tenant_domain(**domain_data)
+            if domain is None:
+                raise CommandError("Missing required domain fields")
+
+        if options.get("s", None):
+            self.stdout.write("Create superuser for %s" % tenant_data["schema_name"])
+            call_command(
+                "create_tenant_superuser",
+                schema_name=tenant_data["schema_name"],
+                interactive=True,
+            )
+
+    def store_tenant(self, **fields):
+        try:
+            tenant = get_tenant_model().objects.create(**fields)
+            return tenant
+        except exceptions.ValidationError as e:
+            self.stderr.write("Error: %s" % "; ".join(e.messages))
+            return None
+        except IntegrityError:
+            return None
+
+    def store_tenant_domain(self, **fields):
+        try:
+            domain = get_tenant_domain_model().objects.create(**fields)
+            domain.save()
+            return domain
+        except exceptions.ValidationError as e:
+            self.stderr.write("Error: %s" % "; ".join(e.messages))
+            return None
+        except IntegrityError:
+            return None


### PR DESCRIPTION
Hey there,

this PR aims on improving the `create_tenant` management command a tiny bit. On tenant creation it extends the "paid until" input prompt with the expected format (YYYY-MM-DD). It also extends the "on trial" input with "('True' or 'False')". Furthermore the `IntegrityErrors` are now printed with `stderr`. This is particularly useful when you enter a domain wich already exists. Before this the input loop would simply start again with no notification why.